### PR TITLE
Preserve the complete committed population in snapshot preflight

### DIFF
--- a/ipfs_datasets_py/logic/software_contracts/semantic_index/COMMITTED_SNAPSHOTS.md
+++ b/ipfs_datasets_py/logic/software_contracts/semantic_index/COMMITTED_SNAPSHOTS.md
@@ -1,0 +1,46 @@
+# Complete committed snapshots
+
+The ordinary `snapshot_repository` API retains its existing traversal exclusions.
+For an independent reconstruction that must account for every committed path,
+use the explicitly named APIs from `semantic_index.committed_snapshot`:
+
+```python
+plan = preflight_committed_repository(
+    repository, repository_id=repository_id,
+    expected_commit=commit_oid, expected_tree=tree_oid,
+)
+# plan.entries contains exact raw paths, modes, object IDs and blob sizes.
+# A deficiency returns the full metadata plan, never a reduced population.
+if not plan.budget_violations:
+    snapshot = snapshot_committed_repository(
+        repository, repository_id=repository_id,
+        expected_commit=commit_oid, expected_tree=tree_oid,
+        expected_population_cid=plan.population_cid,
+    )
+```
+
+Both APIs require the exact repository root, a clean checkout, full HEAD commit
+and tree IDs, and an index without skip-worktree or assume-unchanged hints. They
+observe source identity before and after acquisition, ignore Git replacement
+objects and ambient `GIT_*` overrides, and preserve every committed raw path.
+These checks detect ordinary drift; the native caller still owns mutation fences
+and must independently qualify the actual loaded producer and execution request.
+
+Preflight reads bounded Git metadata, without requesting blob contents. Its
+population CID binds the repository identity, commit, tree and all entries.
+Blob totals count every path, including repeated object IDs. Gitlinks have no
+local blob size; symlinks count their committed blob bytes. Metadata overflow or
+unavailable object sizes fail closed. Entry, per-blob and total size deficiencies
+are reported together, and acquisition refuses them before requesting any blob.
+
+Complete scope bypasses traversal exclusions only. Existing opaque handling for
+malformed paths, symlinks, gitlinks and unsupported contents remains visible.
+Gitlinks require separate admitted repository acquisitions for forest coverage.
+Blob acquisition checks both the recorded size and Git object hash.
+
+The snapshot and semantic pipeline still retain content in memory. Increasing
+the 128 MiB aggregate default does not qualify a multi-gigabyte producer. Such a
+producer needs bounded streaming or chunked content storage, streaming hashes,
+parser limits, and a compatible scanner/state builder before its larger limits
+can be admitted. A plan or matching snapshot is diagnostic content; neither
+grants semantic acceptance, runtime settlement or completion authority.

--- a/ipfs_datasets_py/logic/software_contracts/semantic_index/committed_snapshot.py
+++ b/ipfs_datasets_py/logic/software_contracts/semantic_index/committed_snapshot.py
@@ -1,0 +1,281 @@
+"""Explicit complete committed populations with bounded metadata preflight.
+
+Unlike ordinary filtered snapshots, these APIs include every committed path.
+They never traverse the working filesystem to discover input files. Preflight
+reads Git metadata only; acquisition retains the existing in-memory snapshot
+representation and therefore refuses unqualified per-file/aggregate budgets.
+Neither a population digest nor a snapshot grants semantic acceptance authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import selectors
+import signal
+import subprocess
+import time
+from typing import Any
+
+from ipfs_datasets_py.logic.software_contracts.content import cid_for_structured
+from .snapshot import (
+    DEFAULT_MAX_ENTRIES, DEFAULT_MAX_FILE_BYTES, GIT_COMMAND_TIMEOUT_SECONDS,
+    GitCommandTimeout, GitSnapshotError, RepositorySnapshot, SnapshotError,
+    _entry, _git_oid, _malformed_raw, _opaque, _raw_display, _text,
+)
+
+DEFAULT_MAX_TOTAL_BYTES = 128 * 1024 * 1024
+DEFAULT_MAX_METADATA_BYTES = 32 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class CommittedPopulationEntry:
+    raw_path_hex: str
+    git_mode: str
+    object_type: str
+    git_object_oid: str
+    size_bytes: int | None
+
+    @property
+    def path(self) -> str:
+        return _raw_display(bytes.fromhex(self.raw_path_hex))
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(raw_path_hex=self.raw_path_hex, git_mode=self.git_mode,
+                    object_type=self.object_type, git_object_oid=self.git_object_oid,
+                    size_bytes=self.size_bytes)
+
+
+@dataclass(frozen=True)
+class CommittedPopulationPlan:
+    repository_id: str
+    commit: str
+    tree: str
+    entries: tuple[CommittedPopulationEntry, ...]
+    max_entries: int
+    max_file_bytes: int
+    max_total_bytes: int
+    max_metadata_bytes: int
+
+    @property
+    def blob_count(self) -> int:
+        return sum(entry.object_type == "blob" for entry in self.entries)
+
+    @property
+    def total_blob_bytes(self) -> int:
+        # Count bytes per committed path, including repeated blob OIDs.
+        return sum(entry.size_bytes or 0 for entry in self.entries)
+
+    @property
+    def maximum_blob_bytes(self) -> int:
+        return max((entry.size_bytes or 0 for entry in self.entries), default=0)
+
+    @property
+    def budget_violations(self) -> tuple[str, ...]:
+        return tuple(name for name, failed in (
+            ("max_entries", len(self.entries) > self.max_entries),
+            ("max_file_bytes", self.maximum_blob_bytes > self.max_file_bytes),
+            ("max_total_bytes", self.total_blob_bytes > self.max_total_bytes),
+        ) if failed)
+
+    def population_payload(self) -> dict[str, Any]:
+        return {"schema": "ipfs-datasets.complete-committed-population@1",
+                "repository_id": self.repository_id, "commit": self.commit, "tree": self.tree,
+                "scope": "complete-committed", "exclusions": [],
+                "entries": [entry.to_dict() for entry in self.entries]}
+
+    @property
+    def population_cid(self) -> str:
+        return cid_for_structured(self.population_payload())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**self.population_payload(), "population_cid": self.population_cid,
+                "entry_count": len(self.entries), "blob_count": self.blob_count,
+                "total_blob_bytes": self.total_blob_bytes, "maximum_blob_bytes": self.maximum_blob_bytes,
+                "limits": {name: getattr(self, name) for name in (
+                    "max_entries", "max_file_bytes", "max_total_bytes", "max_metadata_bytes")},
+                "budget_violations": list(self.budget_violations),
+                "blob_bytes_acquired": 0, "acceptance_authority": False}
+
+
+class CommittedPopulationBudgetError(SnapshotError):
+    def __init__(self, plan: CommittedPopulationPlan):
+        super().__init__("committed population exceeds " + ", ".join(plan.budget_violations))
+        self.plan = plan
+
+
+def _run_git(root: Path, args: tuple[str, ...], maximum_bytes: int) -> bytes:
+    """Bound both Git output streams before retaining them in memory."""
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    argv = ["git", "--no-optional-locks", "--no-replace-objects", "-c", "core.fsmonitor=false",
+            "-c", "core.hooksPath=/dev/null", "-C", str(root), *args]
+    try:
+        child = subprocess.Popen(argv, env=env, stdin=subprocess.DEVNULL,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
+    except OSError as exc:
+        raise GitSnapshotError("committed Git observation unavailable") from exc
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    deadline = time.monotonic() + GIT_COMMAND_TIMEOUT_SECONDS
+    try:
+        with selectors.DefaultSelector() as selector:
+            selector.register(child.stdout, selectors.EVENT_READ, "stdout")
+            selector.register(child.stderr, selectors.EVENT_READ, "stderr")
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise GitCommandTimeout("committed Git observation timed out")
+                for key, _ in selector.select(min(remaining, 0.1)):
+                    chunk = os.read(key.fileobj.fileno(), 65536)
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    buffer = buffers[key.data]
+                    limit = maximum_bytes if key.data == "stdout" else 65536
+                    if len(buffer) + len(chunk) > limit:
+                        raise GitSnapshotError("committed Git output exceeds acquisition budget")
+                    buffer.extend(chunk)
+        try:
+            child.wait(timeout=max(0.01, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired as exc:
+            raise GitCommandTimeout("committed Git observation timed out") from exc
+        if child.returncode or buffers["stderr"]:
+            raise GitSnapshotError("committed Git observation failed or warned")
+        return bytes(buffers["stdout"])
+    except BaseException:
+        # Retain the unreaped leader until its own process group is fenced.
+        if child.returncode is None:
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            child.wait(timeout=5)
+        raise
+    finally:
+        child.stdout.close()
+        child.stderr.close()
+
+
+def _fence(root: Path, commit: str, tree: str, limit: int) -> str:
+    observed_root = _run_git(root, ("rev-parse", "--show-toplevel"), limit).decode().strip()
+    if Path(observed_root).resolve() != root:
+        raise GitSnapshotError("committed request must name the exact repository root")
+    if _run_git(root, ("rev-parse", "--verify", "HEAD"), limit).decode().strip() != commit:
+        raise GitSnapshotError("HEAD differs from requested committed population")
+    if _run_git(root, ("cat-file", "-t", commit), limit).strip() != b"commit":
+        raise GitSnapshotError("requested object is not a commit")
+    if _run_git(root, ("rev-parse", "--verify", commit + "^{tree}"), limit).decode().strip() != tree:
+        raise GitSnapshotError("tree differs from requested committed population")
+    if _run_git(root, ("status", "--porcelain=v1", "-z", "--untracked-files=all"), limit):
+        raise GitSnapshotError("complete committed acquisition requires a clean checkout")
+    flags = _run_git(root, ("ls-files", "-v", "-z"), limit)
+    if any(row and (chr(row[0]).islower() or row[:1] == b"S") for row in flags.split(b"\0")):
+        raise GitSnapshotError("source index hides tracked bytes")
+    index = _run_git(root, ("ls-files", "--stage", "-z"), limit)
+    return hashlib.sha256(flags + b"\0" + index).hexdigest()
+
+
+def preflight_committed_repository(
+    repository: str | os.PathLike[str], *, expected_commit: str, expected_tree: str,
+    repository_id: str, max_entries: int = DEFAULT_MAX_ENTRIES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES, max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    max_metadata_bytes: int = DEFAULT_MAX_METADATA_BYTES,
+) -> CommittedPopulationPlan:
+    """Inventory every committed entry without acquiring or parsing blob bytes.
+
+    Per-file/aggregate deficiencies are returned in the complete plan. Metadata
+    output itself is bounded and fails closed instead of yielding partial scope.
+    Gitlinks are retained as references; this API does not acquire their forests.
+    """
+    commit, tree = _git_oid(expected_commit, "commit"), _git_oid(expected_tree, "tree")
+    if not commit or not tree:
+        raise GitSnapshotError("full commit and tree object ids are required")
+    identity = _text(repository_id, "repository_id")
+    if any(type(value) is not int or value < 1 for value in (
+            max_entries, max_file_bytes, max_total_bytes, max_metadata_bytes)):
+        raise SnapshotError("committed acquisition limits must be positive integers")
+    root = Path(repository).resolve(strict=True)
+    before = _fence(root, commit, tree, max_metadata_bytes)
+    raw = _run_git(root, ("ls-tree", "-r", "-l", "-z", "--full-tree", tree), max_metadata_bytes)
+    entries = []
+    paths = set()
+    for row in raw.split(b"\0"):
+        if not row:
+            continue
+        try:
+            metadata, path = row.split(b"\t", 1)
+            mode, kind, oid, size = metadata.decode("ascii").split()
+            _git_oid(oid, "committed object")
+            if (mode, kind) not in {("100644", "blob"), ("100755", "blob"),
+                                    ("120000", "blob"), ("160000", "commit")}:
+                raise ValueError("invalid committed object kind")
+            if kind == "blob":
+                if not size.isascii() or not size.isdecimal():
+                    raise ValueError("unavailable committed blob size")
+                measured = int(size)
+            else:
+                if size != "-":
+                    raise ValueError("invalid gitlink size")
+                measured = None
+            if not path or path in paths:
+                raise ValueError("missing or duplicate committed path")
+            paths.add(path)
+            entries.append(CommittedPopulationEntry(path.hex(), mode, kind, oid, measured))
+        except (ValueError, SnapshotError) as exc:
+            raise GitSnapshotError("invalid committed population inventory") from exc
+    if _fence(root, commit, tree, max_metadata_bytes) != before:
+        raise GitSnapshotError("source index changed during committed preflight")
+    return CommittedPopulationPlan(identity, commit, tree, tuple(sorted(entries, key=lambda e: e.raw_path_hex)),
+                                   max_entries, max_file_bytes, max_total_bytes, max_metadata_bytes)
+
+
+def snapshot_committed_repository(
+    repository: str | os.PathLike[str], *, expected_commit: str, expected_tree: str,
+    repository_id: str, max_entries: int = DEFAULT_MAX_ENTRIES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES, max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    max_metadata_bytes: int = DEFAULT_MAX_METADATA_BYTES, expected_population_cid: str | None = None,
+) -> RepositorySnapshot:
+    """Acquire a complete committed population only after its budget is admitted.
+
+    Calling this separate API explicitly selects complete committed scope.
+    Ordinary snapshot_repository exclusions and identities remain unchanged.
+    The caller must bind the plan/limits and producer revision to any subsequent
+    independent verification request; this function is not an acceptance issuer.
+    """
+    plan = preflight_committed_repository(
+        repository, expected_commit=expected_commit, expected_tree=expected_tree,
+        repository_id=repository_id, max_entries=max_entries, max_file_bytes=max_file_bytes,
+        max_total_bytes=max_total_bytes, max_metadata_bytes=max_metadata_bytes)
+    if expected_population_cid is not None and expected_population_cid != plan.population_cid:
+        raise GitSnapshotError("committed population differs from requested preflight")
+    if plan.budget_violations:
+        raise CommittedPopulationBudgetError(plan)
+    root = Path(repository).resolve(strict=True)
+    before = _fence(root, plan.commit, plan.tree, max_metadata_bytes)
+    entries = []
+    for item in plan.entries:
+        raw, oid = bytes.fromhex(item.raw_path_hex), item.git_object_oid
+        if _malformed_raw(raw) or item.git_mode == "120000" or item.object_type != "blob":
+            reason = "malformed_path" if _malformed_raw(raw) else "symlink_or_nonregular"
+            entries.append(_opaque(item.path, reason, item.size_bytes, raw=raw, oid=oid,
+                                   disposition="clean", head_oid=oid))
+            continue
+        data = _run_git(root, ("cat-file", "blob", oid), item.size_bytes + 1)
+        header = b"blob " + str(len(data)).encode("ascii") + b"\0"
+        algorithm = hashlib.sha1 if len(oid) == 40 else hashlib.sha256
+        if len(data) != item.size_bytes or algorithm(header + data).hexdigest() != oid:
+            raise GitSnapshotError("captured blob differs from committed object identity")
+        entries.append(_entry(item.path, raw, data, max_file_bytes, oid,
+                              disposition="clean", head_oid=oid, acquisition="git-object"))
+    if _fence(root, plan.commit, plan.tree, max_metadata_bytes) != before:
+        raise GitSnapshotError("source index changed during complete committed acquisition")
+    result = RepositorySnapshot(plan.repository_id, tuple(entries), "git-clean",
+                                max_file_bytes, max_entries, plan.tree, plan.commit, ())
+    if tuple(entry.raw_path_hex for entry in result.entries) != tuple(entry.raw_path_hex for entry in plan.entries):
+        raise GitSnapshotError("complete committed acquisition changed population")
+    return result
+
+
+__all__ = ["CommittedPopulationEntry", "CommittedPopulationPlan", "CommittedPopulationBudgetError",
+           "preflight_committed_repository", "snapshot_committed_repository"]

--- a/tests/unit/logic/software_contracts/semantic_index/test_committed_snapshot.py
+++ b/tests/unit/logic/software_contracts/semantic_index/test_committed_snapshot.py
@@ -1,0 +1,199 @@
+"""Complete committed coverage is explicit and never inferred from a partial scan."""
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from ipfs_datasets_py.logic.software_contracts.semantic_index import committed_snapshot as c
+from ipfs_datasets_py.logic.software_contracts.semantic_index.snapshot import snapshot_repository
+
+
+def git(root, *args, data=None):
+    return subprocess.check_output(["git", "-c", "core.hooksPath=/dev/null", "-C", str(root), *args],
+                                   input=data, stderr=subprocess.DEVNULL).decode().strip()
+
+
+def commit(root):
+    git(root, "add", "-A")
+    git(root, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+        "commit", "-qm", "fixture")
+    return dict(expected_commit=git(root, "rev-parse", "HEAD"),
+                expected_tree=git(root, "rev-parse", "HEAD^{tree}"), repository_id="fixture:complete")
+
+
+@pytest.fixture
+def source(tmp_path):
+    root = tmp_path / "source"
+    root.mkdir()
+    git(root, "init", "-b", "main")
+    (root / "module.py").write_bytes(b"value = 1\n")
+    return root, commit(root)
+
+
+def test_explicit_complete_scope_includes_normally_excluded_committed_paths(source):
+    root, _ = source
+    for relative in ("coverage/report.py", "venv/required.py"):
+        path = root / relative
+        path.parent.mkdir()
+        path.write_bytes(b"value = 1\n")
+    request = commit(root)
+    ordinary = snapshot_repository(root, exclusions=())
+    assert [entry.path for entry in ordinary.entries] == ["module.py"]
+    plan = c.preflight_committed_repository(root, **request)
+    assert [entry.path for entry in plan.entries] == ["coverage/report.py", "module.py", "venv/required.py"]
+    assert plan.blob_count == 3
+    assert plan.total_blob_bytes == 30  # Shared blob OIDs still count per path.
+    assert plan.maximum_blob_bytes == 10
+    snapshot = c.snapshot_committed_repository(root, **request, expected_population_cid=plan.population_cid)
+    assert [entry.path for entry in snapshot.entries] == [entry.path for entry in plan.entries]
+    assert snapshot.exclusions == ()
+    assert all(entry.captured_bytes == b"value = 1\n" for entry in snapshot.entries)
+    assert not any(entry.path.startswith(".git/") for entry in snapshot.entries)
+    assert snapshot_repository(root, exclusions=()).snapshot_cid == ordinary.snapshot_cid
+
+
+@pytest.mark.parametrize("limits,expected", [
+    ({"max_file_bytes": 9}, ("max_file_bytes",)),
+    ({"max_total_bytes": 9}, ("max_total_bytes",)),
+    ({"max_file_bytes": 9, "max_total_bytes": 9}, ("max_file_bytes", "max_total_bytes")),
+])
+def test_metadata_plan_reports_exact_budget_deficiency_before_blob_reads(source, monkeypatch, limits, expected):
+    root, request = source
+    real_git = c._run_git
+    def forbid_blob_acquisition(root, args, limit):
+        assert args[:2] != ("cat-file", "blob"), "budgets must be checked before blob acquisition"
+        return real_git(root, args, limit)
+    monkeypatch.setattr(c, "_run_git", forbid_blob_acquisition)
+    plan = c.preflight_committed_repository(root, **request, **limits)
+    assert plan.total_blob_bytes == plan.maximum_blob_bytes == 10
+    assert plan.budget_violations == expected
+    assert plan.to_dict()["blob_bytes_acquired"] == 0
+    assert plan.to_dict()["entries"][0]["git_object_oid"] == git(root, "rev-parse", "HEAD:module.py")
+    with pytest.raises(c.CommittedPopulationBudgetError) as error:
+        c.snapshot_committed_repository(root, **request, **limits)
+    assert error.value.plan == plan
+
+
+def test_entry_budget_refuses_whole_population_without_partial_snapshot(source, monkeypatch):
+    root, _ = source
+    (root / "second.py").write_text("other = 2\n")
+    request = commit(root)
+    plan = c.preflight_committed_repository(root, **request, max_entries=1)
+    assert len(plan.entries) == 2
+    assert plan.budget_violations == ("max_entries",)
+    with pytest.raises(c.CommittedPopulationBudgetError):
+        c.snapshot_committed_repository(root, **request, max_entries=1)
+
+
+def test_dirty_checkout_and_hidden_index_bytes_are_refused(source):
+    root, request = source
+    (root / "module.py").write_bytes(b"value = 2\n")
+    with pytest.raises(c.GitSnapshotError, match="clean checkout"):
+        c.preflight_committed_repository(root, **request)
+    git(root, "update-index", "--assume-unchanged", "module.py")
+    with pytest.raises(c.GitSnapshotError, match="hides tracked bytes"):
+        c.preflight_committed_repository(root, **request)
+
+
+def test_wrong_unreachable_and_tampered_refs_are_refused(source):
+    root, request = source
+    unreachable = git(root, "-c", "user.name=Fixture", "-c", "user.email=test@example.invalid",
+                      "commit-tree", request["expected_tree"], "-m", "unreachable")
+    assert unreachable != request["expected_commit"]
+    with pytest.raises(c.GitSnapshotError, match="HEAD differs"):
+        c.preflight_committed_repository(root, **dict(request, expected_commit=unreachable))
+    with pytest.raises(c.GitSnapshotError, match="HEAD differs"):
+        c.preflight_committed_repository(root, **dict(request, expected_commit="0" * 40))
+    with pytest.raises(c.GitSnapshotError, match="tree differs"):
+        c.preflight_committed_repository(root, **dict(request, expected_tree="0" * 40))
+    (root / ".git/refs/heads/main").write_text("0" * 40 + "\n")
+    with pytest.raises(c.GitSnapshotError):
+        c.preflight_committed_repository(root, **request)
+
+
+def test_missing_blob_is_refused_by_metadata_preflight(source, monkeypatch):
+    root, request = source
+    oid = git(root, "rev-parse", "HEAD:module.py")
+    (root / ".git/objects" / oid[:2] / oid[2:]).unlink()
+    with pytest.raises(c.GitSnapshotError):
+        c.preflight_committed_repository(root, **request)
+
+
+def test_git_replacement_cannot_substitute_requested_blob(source):
+    root, request = source
+    original = git(root, "rev-parse", "HEAD:module.py")
+    replacement = git(root, "hash-object", "-w", "--stdin", data=b"evil = 999\n")
+    git(root, "replace", original, replacement)
+    snapshot = c.snapshot_committed_repository(root, **request)
+    assert snapshot.entries[0].git_blob_oid == original
+    assert snapshot.entries[0].captured_bytes == b"value = 1\n"
+
+
+def test_tampered_blob_bytes_and_population_binding_are_refused(source, monkeypatch):
+    root, request = source
+    with pytest.raises(c.GitSnapshotError, match="requested preflight"):
+        c.snapshot_committed_repository(root, **request, expected_population_cid="tampered")
+    real_git = c._run_git
+    def tampered(root, args, limit):
+        if args[:2] == ("cat-file", "blob"):
+            return b"value = 9\n"
+        return real_git(root, args, limit)
+    monkeypatch.setattr(c, "_run_git", tampered)
+    with pytest.raises(c.GitSnapshotError, match="object identity"):
+        c.snapshot_committed_repository(root, **request)
+
+
+def test_head_move_during_metadata_inventory_is_refused(source, monkeypatch):
+    root, original = source
+    (root / "module.py").write_bytes(b"value = 2\n")
+    other = commit(root)
+    git(root, "reset", "--hard", original["expected_commit"])
+    real_git = c._run_git
+    def move_head(root, args, limit):
+        data = real_git(root, args, limit)
+        if args[0] == "ls-tree":
+            git(root, "update-ref", "HEAD", other["expected_commit"])
+        return data
+    monkeypatch.setattr(c, "_run_git", move_head)
+    with pytest.raises(c.GitSnapshotError, match="HEAD differs"):
+        c.preflight_committed_repository(root, **original)
+
+
+def test_gitlinks_symlinks_and_non_utf8_names_remain_explicit(source):
+    root, original = source
+    (root / "linked.py").symlink_to("module.py")
+    raw_path = os.fsencode(root) + b"/invalid-\xff.py"
+    descriptor = os.open(raw_path, os.O_WRONLY | os.O_CREAT, 0o600)
+    os.write(descriptor, b"x = 1\n")
+    os.close(descriptor)
+    (root / "nested").mkdir()
+    git(root, "update-index", "--add", "--cacheinfo", "160000", original["expected_commit"], "nested")
+    request = commit(root)
+    plan = c.preflight_committed_repository(root, **request)
+    snapshot = c.snapshot_committed_repository(root, **request)
+    assert {entry.raw_path_hex for entry in snapshot.entries} == {entry.raw_path_hex for entry in plan.entries}
+    by_path = {entry.path: entry for entry in snapshot.entries}
+    assert by_path["linked.py"].opaque_reason == "symlink_or_nonregular"
+    assert by_path["nested"].opaque_reason == "symlink_or_nonregular"
+    malformed = next(entry for entry in snapshot.entries if entry.raw_path_hex == b"invalid-\xff.py".hex())
+    assert malformed.opaque_reason == "malformed_path"
+
+
+def test_subdirectory_and_metadata_overflow_never_downgrade_to_filesystem(source):
+    root, request = source
+    child = root / "ignored-child"
+    child.mkdir()
+    with pytest.raises(c.GitSnapshotError, match="exact repository root"):
+        c.preflight_committed_repository(child, **request)
+    with pytest.raises(c.GitSnapshotError, match="acquisition budget"):
+        c.preflight_committed_repository(root, **request, max_metadata_bytes=1)
+
+
+@pytest.mark.parametrize("field,value", [("max_entries", True), ("max_file_bytes", 0),
+                                        ("max_total_bytes", -1), ("max_metadata_bytes", 0)])
+def test_invalid_acquisition_limits_are_rejected(source, field, value):
+    root, request = source
+    with pytest.raises(c.SnapshotError, match="positive integers"):
+        c.preflight_committed_repository(root, **request, **{field: value})


### PR DESCRIPTION
Complete reconstruction currently loses committed files under built-in exclusion paths such as coverage and virtual-environment directories. Add an explicit complete committed snapshot API and metadata-only preflight that bind exact Git population, object identity, and byte budgets before reading blob content. Existing snapshot defaults remain unchanged.

Validation: 101 snapshot, authority, and scanner tests passed. A read-only preflight of SPAR retained all 15,770 committed entries, including 47 previously excluded paths, without acquiring any blobs. Its 2.12 GB population still exceeds existing limits; streaming representation and native qualification are separate work.
