### PR TITLE
Add bounded Git-backed chunk manifests and verified frame reads

### DIFF
--- a/ipfs_datasets_py/logic/software_contracts/content.py
+++ b/ipfs_datasets_py/logic/software_contracts/content.py
@@ -221,6 +221,28 @@ def cid_for_bytes(data: bytes) -> str:
     return _cid_from_digest_bytes(payload, codec=SOURCE_CODEC)
 
 
+def cid_for_byte_chunks(chunks: Iterable[bytes], *, max_chunk_bytes: int) -> str:
+    """Hash every source byte with bounded frames and the ordinary raw CID.
+
+    This consumes the iterator completely and retains no source bytes. A
+    supplied or partially consumed iterator is not evidence of full hashing.
+    Chunk boundaries do not change the source content identity.
+    """
+    import hashlib
+    from multiformats import CID, multihash
+
+    if type(max_chunk_bytes) is not int or max_chunk_bytes < 1:
+        raise ContentIdentityError("max_chunk_bytes must be a positive integer")
+    digest = hashlib.sha256()
+    for chunk in chunks:
+        _require_bytes(chunk)
+        if len(chunk) > max_chunk_bytes:
+            raise ContentIdentityError("source frame exceeds max_chunk_bytes")
+        digest.update(chunk)
+    return str(CID(CID_BASE, CID_VERSION, SOURCE_CODEC,
+                   multihash.wrap(digest.digest(), MULTIHASH_TYPE)))
+
+
 def cid_for_obj(obj: Any) -> str:
     """Return the structured CIDv1 (dag-json / sha2-256 / base32).
 
@@ -554,6 +576,7 @@ __all__ = [
     "StructuredIdentityError",
     "canonical_dag_json_bytes",
     "cid_for_bytes",
+    "cid_for_byte_chunks",
     "cid_for_obj",
     "cid_for_structured",
     "cid_vectors_document",

--- a/ipfs_datasets_py/logic/software_contracts/semantic_index/CHUNKED_SNAPSHOTS.md
+++ b/ipfs_datasets_py/logic/software_contracts/semantic_index/CHUNKED_SNAPSHOTS.md
@@ -1,0 +1,95 @@
+# Bounded committed content references
+
+`snapshot_chunked_repository` is a separate, explicit producer. It discovers the
+complete committed population through metadata preflight, reads each unique
+Git blob once, and verifies its full Git object hash and raw SHA-256 source CID.
+Repeated paths retain their individual entries while sharing one blob manifest.
+Symlink blob bytes are hashed without following their targets. Gitlinks retain
+their exact commit references and require separate forest acquisition.
+
+```python
+from .chunked_snapshot import (
+    ChunkedSnapshotLimits, snapshot_chunked_repository, project_chunked_repository,
+)
+
+chunked = snapshot_chunked_repository(
+    root, repository_id=repository_id, expected_commit=commit, expected_tree=tree,
+    limits=ChunkedSnapshotLimits(),
+)
+root_cid, manifest_blocks = chunked.manifest_blocks()
+projection = project_chunked_repository(root, chunked)
+# Feed projection.snapshot to the ordinary scanner, and separately bind
+# projection.chunked_snapshot_cid into the native reconstruction request.
+```
+
+Blob data stays in Git object storage. No working-tree contents, object copies,
+new packs, persistent database or content cache are created. Frames have a fixed
+1 MiB ceiling. Blob manifests record contiguous offsets, lengths and raw chunk
+CIDs. Inventory and blob indexes are paged so every structured manifest block
+also fits within 1 MiB. Metadata, entry count, chunk reference count and unique
+streaming work are independently bounded before content reads. The default work
+budget is 128 MiB; qualifying a larger total stream does not enlarge a frame or
+retained-content limit. A full object must be consumed, hash-checked and the
+source reobserved before a snapshot is returned.
+
+`read_chunked_blob_frame` retrieves one frame from immutable Git storage. It
+hashes the entire requested blob and verifies every chunk reference before
+returning the selected frame, retaining only that frame. Corruption in a later
+chunk cannot be hidden by reading only the beginning. Compressed Git objects
+currently require a whole-blob stream per call; this is bounded-memory access,
+not a persistent random-access cache or verification of other blobs.
+
+`project_chunked_repository` re-reads **every** unique blob and compares all
+manifest identities before returning the existing snapshot representation.
+It never treats a serialized hash claim as verified content. Inputs at most
+4 MiB may be retained for the existing scanner, within a fixed 128 MiB total
+retained-source ceiling. Larger inputs remain present as opaque entries with
+their fully verified source CID and `analysis_budget_exceeded`. These entries
+establish exact content equality; they do not establish semantic analysis of
+oversized code. If the ordinary input population exceeds 128 MiB, projection
+refuses the whole request instead of silently selecting fewer files.
+
+The manifest DAG is metadata only and does not guarantee future Git object
+availability. Missing objects, replacement objects, source/index drift, wrong
+blob bytes, truncated streams, contradictory population claims, or changed
+chunk references fail closed. Git replacement objects are ignored. Subprocess
+streams are time-bounded and their owned children are reaped on failure.
+The trusted isolated Python launcher also gives Git a fixed 128 MiB address-space
+limit before execution. This bounds hidden Git decoder allocations; delta-packed
+objects that cannot decode within that limit fail closed. Packed Git windows
+are fixed at 8 MiB, the packed-window cache at 32 MiB, and the delta-base cache
+at 16 MiB so default large mmap windows do not consume the address-space bound.
+These settings are included in the manifest root. The Python memory test
+does not measure the child. Actual large packed-object behavior still needs
+qualification under this fixed limit before a live population is admitted.
+Decoder errors use `GitBlobDecoderError`, report the configured address-space
+limit, and return no verified manifest. This records a decoder refusal without
+assuming every subprocess failure was caused by memory pressure.
+
+## Consumer and qualification work still required
+
+The existing scanner retains a dictionary of all verified source bytes and a
+second Python/pytest source mapping. A streaming scanner and a compatible pytest
+frontend are still needed when the aggregate ordinary-source population exceeds
+128 MiB. The current AST frontend also needs a qualified large-source strategy;
+opaque large code cannot be promoted to positive analysis coverage.
+
+`semantic_state/source.py` materialization APIs still require whole byte values.
+They need a bounded chunk-backed range reader with the same source identity and
+freshness guarantees. The state builder can consume a bounded projection today,
+but the native request and persisted state must explicitly bind the chunked
+manifest root and store/validate its complete DAG. This change provides no
+untrusted transport deserializer or automatic block-store admission. A future
+consumer must validate closed schemas, frame limits, every reference and full
+population equality before re-verifying Git content.
+The current builder preserves opaque artifacts transitively, but plain
+`RepositoryState` does not supply formal `AnalysisLimitation` records. A qualified
+adapter must explicitly populate that index from the known limitations; an
+empty formal index must not be read as evidence that opaque code was analyzed.
+
+The supervisor PR215 reconstruction consumer still uses the bounded captured
+snapshot API. It has not been switched automatically to this new representation.
+Native producer/import qualification, mutation/owner fences, forest admission,
+independent execution evidence and completion settlement remain required.
+Neither a matching chunked manifest nor an opaque content hash supplies these
+authorities. Ordinary snapshot/scanner behavior is unchanged.

--- a/ipfs_datasets_py/logic/software_contracts/semantic_index/chunked_snapshot.py
+++ b/ipfs_datasets_py/logic/software_contracts/semantic_index/chunked_snapshot.py
@@ -1,0 +1,411 @@
+"""Complete Git populations backed by fully hashed, bounded blob frames.
+
+Manifests retain references, not blob bytes. Git object storage remains the
+content owner. Projection rechecks every blob before returning any verified
+snapshot, and exposes analysis limitations for oversized inputs explicitly.
+No API here grants semantic acceptance, durable availability or completion.
+"""
+
+from __future__ import annotations
+
+from contextlib import closing
+from dataclasses import asdict, dataclass
+import hashlib
+import os
+from pathlib import Path
+import selectors
+import signal
+import subprocess
+import sys
+import time
+from typing import Any, Iterator
+
+from ipfs_datasets_py.logic.software_contracts.content import (
+    canonical_dag_json_bytes, cid_for_byte_chunks, cid_for_bytes, cid_for_structured,
+)
+from .committed_snapshot import CommittedPopulationEntry, preflight_committed_repository, _fence
+from .snapshot import (
+    GIT_COMMAND_TIMEOUT_SECONDS, GitCommandTimeout, GitSnapshotError,
+    RepositorySnapshot, SnapshotEntry, SnapshotError, _entry, _malformed_raw, _opaque,
+)
+
+MAX_FRAME_BYTES = 1024 * 1024
+MAX_MATERIALIZED_FILE_BYTES = 4 * 1024 * 1024
+MAX_RETAINED_SOURCE_BYTES = 128 * 1024 * 1024
+MAX_GIT_DECODER_ADDRESS_BYTES = 128 * 1024 * 1024
+GIT_DECODER_CONFIG = (("core.packedGitWindowSize", "8388608"),
+                      ("core.packedGitLimit", "33554432"),
+                      ("core.deltaBaseCacheLimit", "16777216"))
+_GIT_STREAM_LAUNCHER = (
+    "import os,resource,sys; "
+    "n=int(sys.argv[1]); resource.setrlimit(resource.RLIMIT_AS,(n,n)); "
+    "os.execvp('git',['git',*sys.argv[2:]])"
+)
+
+
+class GitBlobDecoderError(GitSnapshotError):
+    """The bounded decoder failed; content verification did not complete."""
+
+    def __init__(self):
+        super().__init__("bounded Git blob decoder failed or warned")
+        self.decoder_address_limit_bytes = MAX_GIT_DECODER_ADDRESS_BYTES
+
+
+@dataclass(frozen=True)
+class ChunkedSnapshotLimits:
+    frame_bytes: int = MAX_FRAME_BYTES
+    max_entries: int = 20000
+    max_stream_bytes: int = 128 * 1024 * 1024
+    max_chunks: int = 65536
+    max_metadata_bytes: int = 32 * 1024 * 1024
+
+    def __post_init__(self) -> None:
+        if any(type(n) is not int or n < 1 for n in asdict(self).values()):
+            raise SnapshotError("chunked acquisition limits must be positive integers")
+        if self.frame_bytes > MAX_FRAME_BYTES:
+            raise SnapshotError("frame_bytes exceeds the fixed frame bound")
+
+
+@dataclass(frozen=True)
+class BlobChunk:
+    offset: int
+    size_bytes: int
+    source_cid: str
+
+
+@dataclass(frozen=True)
+class ChunkedBlob:
+    git_object_oid: str
+    size_bytes: int
+    source_cid: str
+    chunks: tuple[BlobChunk, ...]
+
+    def payload(self) -> dict[str, Any]:
+        return {"schema": "ipfs-datasets.git-blob-chunks@1",
+                "git_object_oid": self.git_object_oid, "size_bytes": self.size_bytes,
+                "source_cid": self.source_cid,
+                "chunks": [asdict(chunk) for chunk in self.chunks]}
+
+
+@dataclass(frozen=True)
+class ChunkedRepositorySnapshot:
+    repository_id: str
+    git_commit: str
+    git_tree: str
+    population_cid: str
+    entries: tuple[CommittedPopulationEntry, ...]
+    blobs: tuple[ChunkedBlob, ...]
+    limits: ChunkedSnapshotLimits
+
+    def manifest_blocks(self) -> tuple[str, dict[str, bytes]]:
+        """Return a bounded manifest DAG; every structured block is a frame.
+
+        The root and every referenced block are content addressed. Blob data
+        is deliberately absent. A serialized manifest is a reference claim;
+        projection must reverify the objects before using their identities.
+        """
+        blocks: dict[str, bytes] = {}
+        retained = 0
+
+        def put(payload):
+            nonlocal retained
+            raw = canonical_dag_json_bytes(payload)
+            if len(raw) > MAX_FRAME_BYTES:
+                raise SnapshotError("chunk manifest exceeds the fixed frame bound")
+            cid = cid_for_structured(payload)
+            if cid not in blocks:
+                retained += len(raw)
+                if retained > self.limits.max_metadata_bytes:
+                    raise SnapshotError("chunk manifests exceed metadata budget")
+                blocks[cid] = raw
+            return cid
+
+        def pages(records, kind):
+            refs, page, size = [], [], 256
+            for record in records:
+                extent = len(canonical_dag_json_bytes(record)) + 1
+                if page and size + extent > MAX_FRAME_BYTES:
+                    refs.append(put({"schema": "ipfs-datasets.git-chunk-index-page@1",
+                                     "kind": kind, "records": page}))
+                    page, size = [], 256
+                page.append(record)
+                size += extent
+            if page:
+                refs.append(put({"schema": "ipfs-datasets.git-chunk-index-page@1",
+                                 "kind": kind, "records": page}))
+            return refs
+
+        blob_pages = pages(({"git_object_oid": blob.git_object_oid,
+                             "manifest_cid": put(blob.payload())} for blob in self.blobs), "blobs")
+        entry_pages = pages((entry.to_dict() for entry in self.entries), "entries")
+        root = put({"schema": "ipfs-datasets.git-chunked-snapshot@1",
+                    "repository_id": self.repository_id, "git_commit": self.git_commit,
+                    "git_tree": self.git_tree, "population_cid": self.population_cid,
+                    "scope": "complete-committed", "entry_pages": entry_pages,
+                    "blob_pages": blob_pages, "entry_count": len(self.entries),
+                    "unique_blob_count": len(self.blobs), "limits": asdict(self.limits),
+                    "git_decoder_address_bytes": MAX_GIT_DECODER_ADDRESS_BYTES,
+                    "git_decoder_config": dict(GIT_DECODER_CONFIG)})
+        return root, blocks
+
+    @property
+    def snapshot_cid(self) -> str:
+        return self.manifest_blocks()[0]
+
+
+def _git_blob_frames(root: Path, oid: str, size: int, frame_bytes: int) -> Iterator[bytes]:
+    """Stream a fixed object without a subprocess capture_output accumulator."""
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    try:
+        child = subprocess.Popen(
+            [sys.executable, "-I", "-S", "-B", "-c", _GIT_STREAM_LAUNCHER,
+             str(MAX_GIT_DECODER_ADDRESS_BYTES),
+             "--no-optional-locks", "--no-replace-objects", "-c", "core.fsmonitor=false",
+             *(arg for key, value in GIT_DECODER_CONFIG for arg in ("-c", key + "=" + value)),
+             "-c", "core.hooksPath=/dev/null", "-C", str(root), "cat-file", "blob", oid],
+            env=env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, start_new_session=True)
+    except OSError as exc:
+        raise GitSnapshotError("committed blob stream unavailable") from exc
+    pending, errors, received = bytearray(), bytearray(), 0
+    deadline = time.monotonic() + GIT_COMMAND_TIMEOUT_SECONDS
+    try:
+        with selectors.DefaultSelector() as selector:
+            selector.register(child.stdout, selectors.EVENT_READ, "stdout")
+            selector.register(child.stderr, selectors.EVENT_READ, "stderr")
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise GitCommandTimeout("committed blob stream timed out")
+                for key, _ in selector.select(min(remaining, 0.1)):
+                    bound = min(65536, frame_bytes - len(pending)) if key.data == "stdout" else 65536
+                    data = os.read(key.fileobj.fileno(), bound)
+                    if not data:
+                        selector.unregister(key.fileobj)
+                        continue
+                    if key.data == "stderr":
+                        if len(errors) + len(data) > 65536:
+                            raise GitSnapshotError("committed blob error output exceeded budget")
+                        errors.extend(data)
+                        continue
+                    received += len(data)
+                    if received > size:
+                        raise GitSnapshotError("committed blob stream exceeds recorded size")
+                    pending.extend(data)
+                    if len(pending) == frame_bytes:
+                        frame = bytes(pending)
+                        pending.clear()
+                        yield frame
+            if pending:
+                yield bytes(pending)
+        try:
+            child.wait(timeout=max(0.01, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired as exc:
+            raise GitCommandTimeout("committed blob stream timed out") from exc
+        if child.returncode or errors:
+            raise GitBlobDecoderError()
+        if received != size:
+            raise GitSnapshotError("committed blob stream was truncated")
+    except BaseException:
+        if child.returncode is None:
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            child.wait(timeout=5)
+        raise
+    finally:
+        child.stdout.close()
+        child.stderr.close()
+
+
+def _hash_blob(root: Path, oid: str, size: int, frame_bytes: int,
+               *, capture: bool = False, capture_chunk: int | None = None) -> tuple[ChunkedBlob, bytes | None]:
+    digest = hashlib.sha1() if len(oid) == 40 else hashlib.sha256()
+    digest.update(b"blob " + str(size).encode("ascii") + b"\0")
+    chunks, retained, offset = [], bytearray() if capture or capture_chunk is not None else None, 0
+
+    def observed(frames):
+        nonlocal offset
+        for frame in frames:
+            if type(frame) is not bytes or not frame or len(frame) > frame_bytes:
+                raise GitSnapshotError("invalid committed blob frame")
+            digest.update(frame)
+            chunks.append(BlobChunk(offset, len(frame), cid_for_bytes(frame)))
+            offset += len(frame)
+            if offset > size:
+                raise GitSnapshotError("committed blob exceeds recorded size")
+            if retained is not None and (capture or len(chunks) - 1 == capture_chunk):
+                retained.extend(frame)
+            yield frame
+
+    with closing(_git_blob_frames(root, oid, size, frame_bytes)) as frames:
+        source_cid = cid_for_byte_chunks(observed(frames), max_chunk_bytes=frame_bytes)
+    if offset != size or digest.hexdigest() != oid:
+        raise GitSnapshotError("streamed bytes differ from committed object identity")
+    return ChunkedBlob(oid, size, source_cid, tuple(chunks)), bytes(retained) if retained is not None else None
+
+
+def _observe(repository, commit, tree, identity, limits):
+    # Retained-snapshot byte budgets remain unchanged. Streaming work has its
+    # own explicit bound, checked on unique objects before content is read.
+    plan = preflight_committed_repository(
+        repository, expected_commit=commit, expected_tree=tree, repository_id=identity,
+        max_entries=limits.max_entries, max_metadata_bytes=limits.max_metadata_bytes)
+    if len(plan.entries) > limits.max_entries:
+        raise SnapshotError("chunked population exceeds entry budget")
+    sizes = {}
+    for entry in plan.entries:
+        if entry.object_type == "blob":
+            if entry.git_object_oid in sizes and sizes[entry.git_object_oid] != entry.size_bytes:
+                raise GitSnapshotError("committed blob has contradictory sizes")
+            sizes[entry.git_object_oid] = entry.size_bytes
+    if sum(sizes.values()) > limits.max_stream_bytes:
+        raise SnapshotError("unique committed blobs exceed streaming work budget")
+    count = sum((size + limits.frame_bytes - 1) // limits.frame_bytes for size in sizes.values())
+    if count > limits.max_chunks:
+        raise SnapshotError("committed blobs exceed chunk reference budget")
+    estimated_metadata = (2 * len(canonical_dag_json_bytes(plan.population_payload()))
+                          + len(sizes) * 768 + count * 200 + 4096)
+    if estimated_metadata > limits.max_metadata_bytes:
+        raise SnapshotError("committed manifest estimate exceeds metadata budget")
+    # Bound each future blob manifest before reading any content. The exact
+    # manifest/DAG byte limit is checked again before publication.
+    if any(512 + ((size + limits.frame_bytes - 1) // limits.frame_bytes) * 160 > MAX_FRAME_BYTES
+           for size in sizes.values()):
+        raise SnapshotError("committed blob manifest would exceed the fixed frame bound")
+    return plan, sizes
+
+
+def snapshot_chunked_repository(
+    repository: str | os.PathLike[str], *, expected_commit: str, expected_tree: str,
+    repository_id: str, limits: ChunkedSnapshotLimits = ChunkedSnapshotLimits(),
+) -> ChunkedRepositorySnapshot:
+    """Hash the complete population, retaining bounded references only."""
+    if not isinstance(limits, ChunkedSnapshotLimits):
+        raise SnapshotError("chunked acquisition requires typed limits")
+    root = Path(repository).resolve(strict=True)
+    plan, sizes = _observe(root, expected_commit, expected_tree, repository_id, limits)
+    before = _fence(root, plan.commit, plan.tree, limits.max_metadata_bytes)
+    blobs = tuple(_hash_blob(root, oid, size, limits.frame_bytes)[0] for oid, size in sorted(sizes.items()))
+    if _fence(root, plan.commit, plan.tree, limits.max_metadata_bytes) != before:
+        raise GitSnapshotError("source index changed during chunked acquisition")
+    result = ChunkedRepositorySnapshot(repository_id, plan.commit, plan.tree,
+                                       plan.population_cid, plan.entries, blobs, limits)
+    result.manifest_blocks()  # No result escapes before all manifest bounds pass.
+    return result
+
+
+@dataclass(frozen=True)
+class ChunkedProjection:
+    snapshot: RepositorySnapshot
+    chunked_snapshot_cid: str
+    unique_blob_bytes_verified: int
+    retained_source_bytes: int
+
+
+def read_chunked_blob_frame(
+    repository: str | os.PathLike[str], chunked: ChunkedRepositorySnapshot,
+    *, git_object_oid: str, chunk_index: int,
+) -> bytes:
+    """Return one bounded frame after rehashing its complete immutable blob.
+
+    No partial iterator is called whole-object verification. Git compressed
+    objects currently require a full stream per read; this is not an indexed
+    random-access cache. Other blobs are not claimed verified by this read.
+    """
+    if not isinstance(chunked, ChunkedRepositorySnapshot):
+        raise SnapshotError("frame read requires a chunked snapshot")
+    root = Path(repository).resolve(strict=True)
+    plan, sizes = _observe(root, chunked.git_commit, chunked.git_tree,
+                           chunked.repository_id, chunked.limits)
+    if plan.population_cid != chunked.population_cid or plan.entries != chunked.entries:
+        raise GitSnapshotError("chunked manifest differs from complete committed population")
+    claims = {blob.git_object_oid: blob for blob in chunked.blobs}
+    if len(claims) != len(chunked.blobs) or set(claims) != set(sizes):
+        raise GitSnapshotError("chunked manifest omits or duplicates committed blobs")
+    if git_object_oid not in claims:
+        raise GitSnapshotError("frame object is outside the committed population")
+    claim = claims[git_object_oid]
+    if type(chunk_index) is not int or not 0 <= chunk_index < len(claim.chunks):
+        raise SnapshotError("chunk_index is outside the blob manifest")
+    chunked.manifest_blocks()
+    before = _fence(root, plan.commit, plan.tree, chunked.limits.max_metadata_bytes)
+    observed, data = _hash_blob(root, git_object_oid, sizes[git_object_oid],
+                                chunked.limits.frame_bytes, capture_chunk=chunk_index)
+    if observed != claim:
+        raise GitSnapshotError("streamed blob does not verify chunked manifest")
+    if _fence(root, plan.commit, plan.tree, chunked.limits.max_metadata_bytes) != before:
+        raise GitSnapshotError("source index changed during committed frame read")
+    return data
+
+
+def project_chunked_repository(
+    repository: str | os.PathLike[str], chunked: ChunkedRepositorySnapshot,
+    *, max_file_bytes: int = MAX_MATERIALIZED_FILE_BYTES,
+    max_total_bytes: int = MAX_RETAINED_SOURCE_BYTES,
+) -> ChunkedProjection:
+    """Reverify every blob, retaining only bounded inputs for legacy scanners.
+
+    Oversized blobs have verified source identities but remain analysis-opaque;
+    they are never called analyzed or omitted from the exact population. The
+    caller must bind chunked_snapshot_cid alongside the scanner snapshot.
+    """
+    if not isinstance(chunked, ChunkedRepositorySnapshot):
+        raise SnapshotError("projection requires a chunked snapshot")
+    if any(type(n) is not int or n < 1 for n in (max_file_bytes, max_total_bytes)):
+        raise SnapshotError("projection limits must be positive integers")
+    if max_file_bytes > MAX_MATERIALIZED_FILE_BYTES or max_total_bytes > MAX_RETAINED_SOURCE_BYTES:
+        raise SnapshotError("projection exceeds fixed retained-content bounds")
+    root = Path(repository).resolve(strict=True)
+    plan, sizes = _observe(root, chunked.git_commit, chunked.git_tree,
+                           chunked.repository_id, chunked.limits)
+    if plan.population_cid != chunked.population_cid or plan.entries != chunked.entries:
+        raise GitSnapshotError("chunked manifest differs from complete committed population")
+    claims = {blob.git_object_oid: blob for blob in chunked.blobs}
+    if len(claims) != len(chunked.blobs) or set(claims) != set(sizes):
+        raise GitSnapshotError("chunked manifest omits or duplicates committed blobs")
+    eligible = [entry for entry in plan.entries
+                if entry.git_mode in {"100644", "100755"}
+                and not _malformed_raw(bytes.fromhex(entry.raw_path_hex))
+                and entry.size_bytes <= max_file_bytes]
+    if sum(entry.size_bytes for entry in eligible) > max_total_bytes:
+        raise SnapshotError("projection exceeds retained source byte budget")
+    capture = {entry.git_object_oid for entry in eligible}
+    snapshot_cid = chunked.snapshot_cid
+    before = _fence(root, plan.commit, plan.tree, chunked.limits.max_metadata_bytes)
+    captured = {}
+    for oid, size in sorted(sizes.items()):
+        observed, data = _hash_blob(root, oid, size, chunked.limits.frame_bytes, capture=oid in capture)
+        if observed != claims[oid]:
+            raise GitSnapshotError("streamed blob does not verify chunked manifest")
+        if data is not None:
+            captured[oid] = data
+    if _fence(root, plan.commit, plan.tree, chunked.limits.max_metadata_bytes) != before:
+        raise GitSnapshotError("source index changed during chunked projection")
+    entries = []
+    for item in plan.entries:
+        raw, oid = bytes.fromhex(item.raw_path_hex), item.git_object_oid
+        if item.object_type != "blob":
+            entries.append(_opaque(item.path, "symlink_or_nonregular", None, raw=raw,
+                                   oid=oid, disposition="clean", head_oid=oid))
+            continue
+        reason = ("malformed_path" if _malformed_raw(raw) else
+                  "symlink_or_nonregular" if item.git_mode == "120000" else
+                  "analysis_budget_exceeded" if item.size_bytes > max_file_bytes else None)
+        if reason:
+            entries.append(SnapshotEntry(item.path, "opaque", item.size_bytes,
+                                         source_cid=claims[oid].source_cid, opaque_reason=reason,
+                                         raw_path_hex=item.raw_path_hex, git_blob_oid=oid,
+                                         acquisition="git-object", disposition="clean", head_blob_oid=oid))
+        else:
+            entries.append(_entry(item.path, raw, captured[oid], max_file_bytes, oid,
+                                  disposition="clean", head_oid=oid, acquisition="git-object"))
+    snapshot = RepositorySnapshot(plan.repository_id, tuple(entries), "git-clean", max_file_bytes,
+                                  chunked.limits.max_entries, plan.tree, plan.commit, ())
+    return ChunkedProjection(snapshot, snapshot_cid, sum(sizes.values()), sum(map(len, captured.values())))
+
+
+__all__ = ["BlobChunk", "ChunkedBlob", "ChunkedSnapshotLimits", "ChunkedRepositorySnapshot",
+           "ChunkedProjection", "snapshot_chunked_repository", "project_chunked_repository",
+           "read_chunked_blob_frame", "GitBlobDecoderError"]

--- a/tests/unit/logic/software_contracts/semantic_index/test_chunked_snapshot.py
+++ b/tests/unit/logic/software_contracts/semantic_index/test_chunked_snapshot.py
@@ -1,0 +1,335 @@
+"""Real small Git objects exercise the bounded large-population representation."""
+
+from dataclasses import replace
+import json
+import subprocess
+
+import pytest
+
+from ipfs_datasets_py.logic.software_contracts.content import (
+    ContentIdentityError, cid_for_byte_chunks, cid_for_bytes, cid_for_structured,
+)
+from ipfs_datasets_py.logic.software_contracts.semantic_index import chunked_snapshot as c
+from ipfs_datasets_py.logic.software_contracts.semantic_index.scanner import RepositoryScanner
+from ipfs_datasets_py.logic.software_contracts.semantic_state import (
+    build_semantic_state, verify_semantic_state_bundle,
+)
+
+
+def git(root, *args, data=None):
+    return subprocess.check_output(
+        ["git", "-c", "core.hooksPath=/dev/null", "-C", str(root), *args],
+        input=data, stderr=subprocess.DEVNULL).decode().strip()
+
+
+def commit(root):
+    git(root, "add", "-A")
+    git(root, "-c", "user.name=Fixture", "-c", "user.email=test@example.invalid",
+        "commit", "-qm", "fixture")
+    return dict(repository_id="fixture:chunked", expected_commit=git(root, "rev-parse", "HEAD"),
+                expected_tree=git(root, "rev-parse", "HEAD^{tree}"))
+
+
+@pytest.fixture
+def source(tmp_path):
+    root = tmp_path / "source"
+    root.mkdir()
+    git(root, "init", "-b", "main")
+    (root / "module.py").write_bytes(b"def add(a, b):\n    return a + b\n")
+    return root, commit(root)
+
+
+def test_chunk_source_cid_matches_existing_identity_including_empty_source():
+    assert cid_for_byte_chunks([], max_chunk_bytes=2) == cid_for_bytes(b"")
+    assert cid_for_byte_chunks([b"a", b"bc", b"", b"d"], max_chunk_bytes=2) == cid_for_bytes(b"abcd")
+    with pytest.raises(ContentIdentityError, match="frame"):
+        cid_for_byte_chunks([b"abc"], max_chunk_bytes=2)
+    with pytest.raises(TypeError):
+        cid_for_byte_chunks([bytearray(b"ab")], max_chunk_bytes=2)
+
+
+def test_binary_and_oversized_code_are_fully_hashed_and_keep_exact_population(source, monkeypatch):
+    root, _ = source
+    binary = bytes(range(256)) * 512
+    big_code = b"x = 1\n" * 22000
+    (root / "coverage").mkdir()
+    (root / "coverage/blob.bin").write_bytes(binary)
+    (root / "copy.bin").write_bytes(binary)
+    (root / "large.py").write_bytes(big_code)
+    (root / "empty.bin").write_bytes(b"")
+    request = commit(root)
+    seen, frame_lengths = [], []
+    actual = c._git_blob_frames
+
+    def instrumented(path, oid, size, frame_bytes):
+        seen.append(oid)
+        for frame in actual(path, oid, size, frame_bytes):
+            frame_lengths.append(len(frame))
+            yield frame
+
+    monkeypatch.setattr(c, "_git_blob_frames", instrumented)
+    chunked = c.snapshot_chunked_repository(root, **request, limits=c.ChunkedSnapshotLimits(frame_bytes=4096))
+    assert len(chunked.entries) == 5
+    assert len(chunked.blobs) == len(seen) == len(set(seen)) == 4
+    assert max(frame_lengths) <= 4096
+    binary_manifest = next(blob for blob in chunked.blobs if blob.source_cid == cid_for_bytes(binary))
+    assert binary_manifest.size_bytes == len(binary)
+    assert len(binary_manifest.chunks) == 32
+    root_cid, blocks = chunked.manifest_blocks()
+    assert root_cid == chunked.snapshot_cid
+    assert all(len(raw) <= c.MAX_FRAME_BYTES for raw in blocks.values())
+    assert all(cid_for_structured(json.loads(raw)) == cid for cid, raw in blocks.items())
+    assert not any(binary[:256].hex() in raw.decode() for raw in blocks.values())
+
+    # Every blob is read again before any projection is returned. Large code
+    # is content-verified but deliberately not represented as analyzed code.
+    projected = c.project_chunked_repository(root, chunked, max_file_bytes=1024)
+    assert len(seen) == 8
+    assert projected.chunked_snapshot_cid == root_cid
+    assert projected.unique_blob_bytes_verified == len(binary) + len(big_code) + (root / "module.py").stat().st_size
+    assert projected.retained_source_bytes == (root / "module.py").stat().st_size
+    entries = {entry.path: entry for entry in projected.snapshot.entries}
+    for name, data in (("copy.bin", binary), ("coverage/blob.bin", binary), ("large.py", big_code)):
+        assert entries[name].source_cid == cid_for_bytes(data)
+        assert entries[name].captured_bytes is None
+        assert entries[name].opaque_reason == "analysis_budget_exceeded"
+    state = RepositoryScanner(repository_id=request["repository_id"]).scan_snapshot(
+        projected.snapshot, {entry.source_key: entry.captured_bytes for entry in projected.snapshot.entries
+                             if entry.captured_bytes is not None})
+    assert any(symbol.module_path == "module.py" for symbol in state.symbols)
+    assert not any(symbol.module_path == "large.py" for symbol in state.symbols)
+    opaque = {artifact.path: artifact for artifact in state.artifacts if artifact.kind == "opaque"}
+    assert opaque["large.py"].source_cid == cid_for_bytes(big_code)
+    bundle = build_semantic_state(state)
+    assert verify_semantic_state_bundle(bundle).root_cid == bundle.root.root_cid
+    facts = [json.loads(raw) for raw in bundle.blocks.values()]
+    assert any(fact.get("path") == "large.py" and fact.get("source_cid") == cid_for_bytes(big_code)
+               and fact.get("artifact", {}).get("metadata", {}).get("opaque_reason") == "analysis_budget_exceeded"
+               for fact in facts)
+
+
+@pytest.mark.parametrize("changed", ["chunk", "source", "omitted_blob", "entry", "population"])
+def test_tampered_chunk_and_population_claims_cannot_be_projected(source, changed):
+    root, request = source
+    chunked = c.snapshot_chunked_repository(root, **request, limits=c.ChunkedSnapshotLimits(frame_bytes=8))
+    blob = chunked.blobs[0]
+    if changed == "chunk":
+        bad = replace(blob.chunks[0], source_cid=cid_for_bytes(b"tampered"))
+        chunked = replace(chunked, blobs=(replace(blob, chunks=(bad, *blob.chunks[1:])),))
+    elif changed == "source":
+        chunked = replace(chunked, blobs=(replace(blob, source_cid=cid_for_bytes(b"tampered")),))
+    elif changed == "omitted_blob":
+        chunked = replace(chunked, blobs=())
+    elif changed == "entry":
+        chunked = replace(chunked, entries=())
+    else:
+        chunked = replace(chunked, population_cid=cid_for_bytes(b"tampered"))
+    with pytest.raises(c.GitSnapshotError, match="manifest|population"):
+        c.project_chunked_repository(root, chunked)
+
+
+@pytest.mark.parametrize("limits,reason", [
+    (c.ChunkedSnapshotLimits(max_stream_bytes=1), "streaming work"),
+    (c.ChunkedSnapshotLimits(frame_bytes=1, max_chunks=1), "chunk reference"),
+    (c.ChunkedSnapshotLimits(max_metadata_bytes=2000), "metadata budget"),
+])
+def test_stream_work_and_reference_budgets_refuse_before_content_reads(source, monkeypatch, limits, reason):
+    root, request = source
+    monkeypatch.setattr(c, "_git_blob_frames", lambda *args: pytest.fail("blob read beyond preflight budget"))
+    with pytest.raises(c.SnapshotError, match=reason):
+        c.snapshot_chunked_repository(root, **request, limits=limits)
+
+
+def test_projection_retained_budget_cannot_silently_drop_normal_files(source, monkeypatch):
+    root, request = source
+    chunked = c.snapshot_chunked_repository(root, **request)
+    monkeypatch.setattr(c, "_git_blob_frames", lambda *args: pytest.fail("unadmitted retained bytes read"))
+    with pytest.raises(c.SnapshotError, match="retained source"):
+        c.project_chunked_repository(root, chunked, max_total_bytes=1)
+    with pytest.raises(c.SnapshotError, match="fixed retained"):
+        c.project_chunked_repository(root, chunked, max_file_bytes=c.MAX_MATERIALIZED_FILE_BYTES + 1)
+    with pytest.raises(c.SnapshotError, match="fixed frame"):
+        c.ChunkedSnapshotLimits(frame_bytes=c.MAX_FRAME_BYTES + 1)
+
+
+@pytest.mark.parametrize("mutation", ["truncated", "corrupt", "extra"])
+def test_incomplete_or_wrong_git_content_never_produces_a_manifest(source, monkeypatch, mutation):
+    root, request = source
+    original = (root / "module.py").read_bytes()
+    data = original[:-1] if mutation == "truncated" else original + b"!" if mutation == "extra" else b"!" * len(original)
+    def altered(*args):
+        yield data
+    monkeypatch.setattr(c, "_git_blob_frames", altered)
+    with pytest.raises(c.GitSnapshotError, match="recorded size|object identity"):
+        c.snapshot_chunked_repository(root, **request)
+
+
+def test_git_replacement_is_ignored_and_later_object_loss_fails_closed(source):
+    root, request = source
+    original = git(root, "rev-parse", "HEAD:module.py")
+    other = git(root, "hash-object", "-w", "--stdin", data=b"evil = True\n")
+    git(root, "replace", original, other)
+    chunked = c.snapshot_chunked_repository(root, **request)
+    assert chunked.blobs[0].source_cid == cid_for_bytes((root / "module.py").read_bytes())
+    (root / ".git/objects" / original[:2] / original[2:]).unlink()
+    with pytest.raises(c.GitSnapshotError):
+        c.project_chunked_repository(root, chunked)
+
+
+def test_symlink_blob_is_hashed_and_gitlink_remains_an_explicit_forest_boundary(source):
+    root, request = source
+    (root / "link.py").symlink_to("module.py")
+    (root / "nested").mkdir()
+    git(root, "update-index", "--add", "--cacheinfo", "160000", request["expected_commit"], "nested")
+    request = commit(root)
+    chunked = c.snapshot_chunked_repository(root, **request)
+    projected = c.project_chunked_repository(root, chunked)
+    entries = {entry.path: entry for entry in projected.snapshot.entries}
+    assert entries["link.py"].source_cid == cid_for_bytes(b"module.py")
+    assert entries["link.py"].opaque_reason == "symlink_or_nonregular"
+    assert entries["nested"].source_cid is None
+    assert entries["nested"].opaque_reason == "symlink_or_nonregular"
+    assert len(chunked.entries) == 3 and len(chunked.blobs) == 2
+
+
+def test_peak_retained_memory_does_not_follow_large_blob_size(source):
+    import tracemalloc
+    root, _ = source
+    with (root / "large.bin").open("wb") as stream:
+        for _ in range(768):
+            stream.write(b"\x00\xff" * 4096)
+    request = commit(root)
+    cid_for_bytes(b"")
+    cid_for_structured({})
+    tracemalloc.start()
+    try:
+        snapshot = c.snapshot_chunked_repository(root, **request,
+                                                limits=c.ChunkedSnapshotLimits(frame_bytes=65536))
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert sum(blob.size_bytes for blob in snapshot.blobs) > 6 * 1024 * 1024
+    assert peak < 2 * 1024 * 1024
+
+
+def test_inventory_pages_keep_metadata_frames_bounded(source, monkeypatch):
+    root, _ = source
+    for number in range(12):
+        (root / (str(number) + "x" * 140 + ".py")).write_bytes(b"x = 1\n")
+    request = commit(root)
+    monkeypatch.setattr(c, "MAX_FRAME_BYTES", 2048)
+    snapshot = c.snapshot_chunked_repository(root, **request,
+                                            limits=c.ChunkedSnapshotLimits(frame_bytes=64))
+    cid, blocks = snapshot.manifest_blocks()
+    descriptor = json.loads(blocks[cid])
+    assert len(descriptor["entry_pages"]) > 1
+    entries = [entry for ref in descriptor["entry_pages"] for entry in json.loads(blocks[ref])["records"]]
+    assert len(entries) == 13
+    assert all(len(raw) <= 2048 for raw in blocks.values())
+
+
+def test_stalled_blob_child_is_reaped_without_leaking_a_stream(source, monkeypatch):
+    import signal
+    import sys
+    root, _ = source
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"],
+                             stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, start_new_session=True)
+    monkeypatch.setattr(c.subprocess, "Popen", lambda *args, **kwargs: child)
+    monkeypatch.setattr(c, "GIT_COMMAND_TIMEOUT_SECONDS", 0.05)
+    with pytest.raises(c.GitCommandTimeout):
+        list(c._git_blob_frames(root, "a" * 40, 1, 1))
+    assert child.returncode == -signal.SIGKILL
+    assert child.stdout.closed and child.stderr.closed
+
+
+@pytest.mark.parametrize("phase", ["capture", "projection"])
+def test_source_drift_during_content_stream_fails_before_return(source, monkeypatch, phase):
+    root, request = source
+    chunked = c.snapshot_chunked_repository(root, **request)
+    real = c._hash_blob
+    def changed(*args, **kwargs):
+        result = real(*args, **kwargs)
+        (root / "module.py").write_bytes(b"changed = True\n")
+        return result
+    monkeypatch.setattr(c, "_hash_blob", changed)
+    with pytest.raises(c.GitSnapshotError, match="clean checkout"):
+        if phase == "capture":
+            c.snapshot_chunked_repository(root, **request)
+        else:
+            c.project_chunked_repository(root, chunked)
+
+
+def test_frame_read_checks_the_whole_blob_before_returning_bounded_bytes(source, monkeypatch):
+    root, request = source
+    chunked = c.snapshot_chunked_repository(root, **request, limits=c.ChunkedSnapshotLimits(frame_bytes=8))
+    blob = chunked.blobs[0]
+    assert c.read_chunked_blob_frame(root, chunked, git_object_oid=blob.git_object_oid,
+                                     chunk_index=1) == (root / "module.py").read_bytes()[8:16]
+    bad_last = replace(blob.chunks[-1], source_cid=cid_for_bytes(b"bad trailing bytes"))
+    tampered = replace(chunked, blobs=(replace(blob, chunks=(*blob.chunks[:-1], bad_last)),))
+    with pytest.raises(c.GitSnapshotError, match="verify chunked manifest"):
+        c.read_chunked_blob_frame(root, tampered, git_object_oid=blob.git_object_oid, chunk_index=0)
+    monkeypatch.setattr(c, "_hash_blob", lambda *args, **kwargs: pytest.fail("read outside admitted frame"))
+    with pytest.raises(c.GitSnapshotError, match="outside the committed population"):
+        c.read_chunked_blob_frame(root, chunked, git_object_oid="a" * 40, chunk_index=0)
+    with pytest.raises(c.SnapshotError, match="chunk_index"):
+        c.read_chunked_blob_frame(root, chunked, git_object_oid=blob.git_object_oid, chunk_index=True)
+
+
+def test_git_decoder_has_a_fixed_kernel_memory_bound(source, monkeypatch):
+    import resource
+    root, _ = source
+    (root / "module.py").write_bytes(b"x = 1\n" * 10000)
+    commit(root)
+    oid = git(root, "rev-parse", "HEAD:module.py")
+    real_popen, children = c.subprocess.Popen, []
+    def start(*args, **kwargs):
+        child = real_popen(*args, **kwargs)
+        children.append(child)
+        return child
+    monkeypatch.setattr(c.subprocess, "Popen", start)
+    frames = c._git_blob_frames(root, oid, 60000, 4096)
+    try:
+        assert len(next(frames)) == 4096
+        assert resource.prlimit(children[0].pid, resource.RLIMIT_AS) == (
+            c.MAX_GIT_DECODER_ADDRESS_BYTES, c.MAX_GIT_DECODER_ADDRESS_BYTES)
+    finally:
+        frames.close()
+    assert children[0].returncode is not None
+
+
+def test_real_packed_delta_objects_stream_under_decoder_bounds(source):
+    import random
+    root, _ = source
+    base = random.Random(7).randbytes(65536)
+    expected = {}
+    for index in range(12):
+        data = base[:32000] + bytes([index]) + base[32001:]
+        path = root / f"packed-{index}.bin"
+        path.write_bytes(data)
+        expected[git(root, "hash-object", str(path))] = data
+    request = commit(root)
+    git(root, "repack", "-adf", "--window=20", "--depth=10")
+    indexes = list((root / ".git/objects/pack").glob("*.idx"))
+    assert len(indexes) == 1
+    details = git(root, "verify-pack", "-v", str(indexes[0]))
+    assert any(len(row.split()) == 7 and row.split()[1] == "blob" for row in details.splitlines())
+    chunked = c.snapshot_chunked_repository(root, **request,
+                                           limits=c.ChunkedSnapshotLimits(frame_bytes=4096))
+    for blob in chunked.blobs:
+        if blob.git_object_oid in expected:
+            assert blob.source_cid == cid_for_bytes(expected[blob.git_object_oid])
+    oid = next(iter(expected))
+    assert c.read_chunked_blob_frame(root, chunked, git_object_oid=oid,
+                                     chunk_index=2) == expected[oid][8192:12288]
+    cid, blocks = chunked.manifest_blocks()
+    assert json.loads(blocks[cid])["git_decoder_config"] == dict(c.GIT_DECODER_CONFIG)
+
+
+def test_decoder_address_refusal_returns_no_verified_manifest(source, monkeypatch):
+    root, request = source
+    monkeypatch.setattr(c, "MAX_GIT_DECODER_ADDRESS_BYTES", 1024)
+    with pytest.raises(c.GitBlobDecoderError) as refused:
+        c.snapshot_chunked_repository(root, **request)
+    assert refused.value.decoder_address_limit_bytes == 1024


### PR DESCRIPTION
Committed repositories can exceed retained scanner limits even when their Git metadata is intact. Add complete-population manifests that verify unique Git blobs in bounded frames, preserve every committed path, and provide verified frame reads and bounded scanner projection. Oversized inputs retain their content identities with explicit analysis limitations.

Depends on #1260. Data and manifest frames remain at most 1 MiB; Git decoding has a 128 MiB address-space limit and bounded packed-object caches. Existing 4 MiB per-file and 128 MiB retained scanner limits remain unchanged.

Validation: 146 tests passed, including real packed/delta objects, missing or corrupted objects, source drift, decoder refusal, stalled-child cleanup, and a 6 MiB blob with traced Python peak memory below 2 MiB. Git child memory is separately bounded by RLIMIT_AS.

This source API does not complete SPAR admission. Streaming scanners, closed manifest admission/persistence, formal limitation indexing, reconstruction integration, and native qualification remain; no full live SPAR snapshot was acquired.
